### PR TITLE
fix compile error on ./prj_editor/src/toolchains_editor.adb

### DIFF
--- a/prj_editor/src/toolchains_editor.adb
+++ b/prj_editor/src/toolchains_editor.adb
@@ -955,7 +955,7 @@ package body Toolchains_Editor is
          Widget        : Gtk_Widget;
          Ent           : Gtk_Entry;
          Btn           : Gtk_Button := null;
-         Ent_Name      : constant String := To_Lower (Tool'Image) & "_tool";
+         Ent_Name      : constant String := To_Lower (Tool'Img) & "_tool";
          Tool_Label    : constant String := Get_Label (Kind, Tool, Lang);
       begin
          --  Use a combo box with an entry if several possible values have


### PR DESCRIPTION
On line 958,  `Tool'Image` will give compile error, as `'Image` is expecting a type, not an object instance, it should change to either `Tool'Img`.