### PR TITLE
Fix Gtk gutter using Gtk 3.24.

### DIFF
--- a/src_editor/src/src_editor_buffer-line_information.adb
+++ b/src_editor/src/src_editor_buffer-line_information.adb
@@ -1123,6 +1123,7 @@ package body Src_Editor_Buffer.Line_Information is
                   Strs         : GNAT.Strings.String_List :=
                                    (1 => new String'(To_String (Image)));
                begin
+                  Save (Cr);
                   --   ??? Should have a cache
                   Info := Choose_Icon_For_Scale
                     (Gtk.Icon_Theme.Get_Default, Strs, Size, 1, 0);
@@ -1140,6 +1141,7 @@ package body Src_Editor_Buffer.Line_Information is
                         Y + Gdouble ((Line_Height - Size) / 2));
                      Unref (P);
                      Unref (Info);
+                     Restore (Cr);
                   end if;
                end;
             end if;


### PR DESCRIPTION
A missing Save/Restore of the cairo context makes the line numbers
stop being displayed at the first specific icon information like
the fold/unfold or the code-fix one.