### PR TITLE
Rename 'GPS' to 'GNAT Studio' in dialog box that appears when changing status of scripts

### DIFF
--- a/kernel/src/gps-kernel-custom-gui.adb
+++ b/kernel/src/gps-kernel-custom-gui.adb
@@ -707,20 +707,20 @@ package body GPS.Kernel.Custom.GUI is
             Response     : Gtk_Response_Type;
          begin
             Gtk_New (Dialog,
-                     Title  => -"Restart GPS ?",
+                     Title  => -"Restart GNAT Studio ?",
                      Parent => Get_Main_Window (Kernel),
                      Flags  => Modal);
             Gtk_New
               (Label,
                -("You have changed the status of some scripts. You will"
                  & ASCII.LF
-                 & "need to restart GPS to take this change into account."
+                 & "need to restart GNAT Studio to take this change into account."
                  & ASCII.LF & ASCII.LF
-                 & "Do you want to exit GPS now ?"));
+                 & "Do you want to exit GNAT Studio now ?"));
             Pack_Start
               (Get_Content_Area (Dialog),
                Label, Expand => True, Fill => True);
-            Button := Add_Button (Dialog, -"Exit GPS", Gtk_Response_OK);
+            Button := Add_Button (Dialog, -"Exit GNAT Studio", Gtk_Response_OK);
             Button := Add_Button
               (Dialog, -"Will restart later", Gtk_Response_Cancel);
             Grab_Default (Button);


### PR DESCRIPTION
I found a dialog when loading a plugin that asks for the user to restart which uses the old name 'GPS', I changed it to 'GNAT Studio'.